### PR TITLE
Reject `resolve` calls returning nil

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,6 @@
   * [ ] Documentation
   * [ ] Security
   * [ ] Performance
-  * [ ] Cross-compatibility (Clojure/ClojureScript)
 
 ## Reviewer checklist
 
@@ -32,4 +31,3 @@
   * [ ] Documentation
   * [ ] Security
   * [ ] Performance
-  * [ ] Cross-compatibility (Clojure/ClojureScript)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Functions related to Component or protocols will go here.
 
 `implement` is a safer layer over raw metadata-based protocol extension.
 
-> Metadata-based protocol extension might be a reliable solution against [this](https://github.com/clojure/tools.namespace/tree/bb9d7a1e98cc5a1ff53107966c96af6886eb0f5b#warnings-for-protocols) problem.
+> Metadata-based protocol extension has recently proven to be a reliable solution against [this](https://github.com/clojure/tools.namespace/tree/bb9d7a1e98cc5a1ff53107966c96af6886eb0f5b#warnings-for-protocols) problem.
 
 In plain Clojure you might be tempted to do:
 
@@ -36,8 +36,10 @@ However, several things might go wrong:
   * e.g. to a function of not emitted by `defprotocol`
 * What if `start` does not evaluate to a function?
   * i.e. any other kind of value
-  
-`implement` guards you against all of those. It also provides some sugar (symbols don't have to be quoted) and enforcement (you cannot pass anything other than a symbol; this aims to avoid deeply nested, non-reusable code).
+
+`implement` guards you against all of those, preventing the lack of errors (or opaque errors, at best) that you'd get otherwise.
+
+It also provides some sugar (symbols don't have to be quoted) and enforcement (you cannot pass anything other than a symbol; this aims to avoid deeply nested, non-reusable code).
 
 This is how it looks like:
 

--- a/src/nedap/utils/modular/api.clj
+++ b/src/nedap/utils/modular/api.clj
@@ -23,7 +23,7 @@
   {:style/indent 1}
   [object & methods]
   {:pre [(check! (spec/coll-of ::method-pair :min-count 1) (partition 2 methods)
-                 metadata-extension-supported? *clojure-version*)]}
+                 metadata-extension-supported?             *clojure-version*)]}
   (implement/implement object *ns* methods))
 
 (defmacro add-method

--- a/src/nedap/utils/modular/impl/implement.clj
+++ b/src/nedap/utils/modular/impl/implement.clj
@@ -28,7 +28,10 @@
 
 (defn fully-qualify [ns s]
   (if (qualified-symbol? s)
-    (symbol (resolve s)) ;; turns 'component/start into 'com.stuartsierra.component/start
+    ;; turn 'component/start into 'com.stuartsierra.component/start:
+    (do
+      (check! resolve s)
+      (symbol (resolve s)))
     (symbol (str ns) (str s))))
 
 (defn implement [obj ns kvs]

--- a/test/unit/nedap/utils/modular/api/implement.clj
+++ b/test/unit/nedap/utils/modular/api/implement.clj
@@ -45,6 +45,15 @@
       (is (thrown? Exception (eval '(sut/implement {}
                                       foo-impl oooooommmmmggggg))))))
 
+  (testing "spurious aliases in either side of the mapping"
+    (with-out-str
+      (is (thrown? Exception (eval '(sut/implement {}
+                                      made/up inc)))))
+
+    (with-out-str
+      (is (thrown? Exception (eval '(sut/implement {}
+                                      foo made/up))))))
+
   (testing "Implementing incompatible protocols is prevented"
     (is (thrown-with-msg? Exception #"The targeted protocol does not have `:extend-via-metadata` activated."
                           (sut/implement {}


### PR DESCRIPTION
## Brief

Fixes nedap/utils.modular#9

## QA plan

Have a look at the new tests

## Author checklist

* [x] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [x] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] I have self-reviewed the PR prior to assignment, and its build passes
* Specifically, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [x] Correctness
  * [x] Robustness (red paths, failure handling etc)
  * [x] Modular design
  * [x] Test coverage
  * [x] Spec coverage
  * [x] Documentation
  * [x] Security
  * [x] Performance

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Business-facing correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Modular design
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
