### PR TITLE
v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Refer to its test for an example.
 ## Installation
 
 ```clojure
-[com.nedap.staffing-solutions/utils.modular "0.4.0"]
+[com.nedap.staffing-solutions/utils.modular "1.0.0"]
 ````
 
 ## ns organisation

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 ;; Please don't bump the library version by hand - use ci.release-workflow instead.
-(defproject com.nedap.staffing-solutions/utils.modular "0.4.0"
+(defproject com.nedap.staffing-solutions/utils.modular "1.0.0"
   ;; Please keep the dependencies sorted a-z.
   :dependencies [[com.nedap.staffing-solutions/utils.spec "0.9.0"]
                  [com.stuartsierra/component "0.4.0"]


### PR DESCRIPTION
* Delivers https://github.com/nedap/utils.modular/pull/12
* Jumps to 1.0.0 for avoiding the 0.x semver escape hatch.