### PR TITLE
Remove cloverage as dependency on JDK tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,6 @@ workflows:
           lein_test_command: lein with-profile -dev,+ci,+jdk11 do clean, test
           requires:
             - "Ensure artifact isolation, inform of boxed math"
-            - cloverage
           context: Github
           <<: *test_code_filters
       - test_code:
@@ -110,7 +109,6 @@ workflows:
           lein_test_command: lein with-profile -dev,+ci,+jdk11,+production do clean, test
           requires:
             - "Ensure artifact isolation, inform of boxed math"
-            - cloverage
           context: Github
           <<: *test_code_filters
       - deploy:


### PR DESCRIPTION
## Brief

See https://github.com/nedap/utils.modular/pull/25#pullrequestreview-991804468

## QA plan

- N/A

## Author checklist

<!-- Please, before publicizing your PR, open it as a "WIP PR", and then review it using the following. -->

* [ ] I have QAed the functionality
* [x] The PR has a reasonably reviewable size and a meaningful commit history
* [ ] I have run the [branch formatter](https://github.com/nedap/formatting-stack/blob/332a419034ab46fad526a5592f4257353bd695b6/src/formatting_stack/branch_formatter.clj) and observed no new/significative warnings
* [x] The build passes
* [x] I have self-reviewed the PR prior to assignment
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)

## Reviewer checklist

* [ ] I have checked out this branch and reviewed it locally, running it
* [ ] I have QAed the functionality
* [ ] I have reviewed the PR
* Additionally, I have code-reviewed iteratively the PR considering the following aspects in isolation:
  * [ ] Correctness
  * [ ] Robustness (red paths, failure handling etc)
  * [ ] Test coverage
  * [ ] Spec coverage
  * [ ] Documentation
  * [ ] Security
  * [ ] Performance
  * [ ] Breaking API changes
  * [ ] Cross-compatibility (Clojure/ClojureScript)
